### PR TITLE
Prevent duplicates on products with multiple taxons

### DIFF
--- a/core/app/finders/spree/products/find.rb
+++ b/core/app/finders/spree/products/find.rb
@@ -166,7 +166,6 @@ module Spree
         when 'default'
           if taxons?
             products.
-              select("#{Product.table_name}.*, #{Classification.table_name}.position").
               order("#{Classification.table_name}.position" => :asc)
           else
             products


### PR DESCRIPTION
The following Products query was being generated for the show action on the taxons controller:
SELECT DISTINCT spree_products.*, spree_products_taxons.position FROM "spree_products" INNER JOIN... ORDER BY "spree_products_taxons"."position" ASC LIMIT ? OFFSET ?

This meant that any product having n>1 taxons on the same taxonomy would appear n times in the query result for the parent taxon (unless by chance it had the same position on every one of the n taxons).

Since it is not necessary to include the "spree_products_taxons.position" column in the query to be able to ORDER BY it, we can just remove the "select()" line so that it will generate this instead:
SELECT DISTINCT spree_products.* FROM "spree_products" INNER JOIN... ORDER BY "spree_products_taxons"."position" ASC LIMIT ? OFFSET ?
, thus avoiding duplicates.

Essentially a regression of issue https://github.com/spree/spree/issues/1917 .